### PR TITLE
ensure cron is initialized at adapter start

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -89,6 +89,7 @@
         },
         "mode": "schedule",
         "schedule": "*/5 * * * *",
+        "allowInit": true,
         "platform": "javascript/Node.js",
         "materialize": true,
         "loglevel": "info",


### PR DESCRIPTION
by adding ""allowInit": true," the adapter wil run immediately at start and not after 5 minutes (first cron cycle)